### PR TITLE
Fixing CSS conflict

### DIFF
--- a/assets/navigationicons.css
+++ b/assets/navigationicons.css
@@ -10,7 +10,7 @@
 	}
 
 li[data-icon]:before, a[data-icon]:before, .navigationicons-duplicator span:before {
-	font-family: 'navigationicons';
+	font-family: 'navigationicons' !important;
 	speak: none;
 	font-style: normal;
 	font-weight: normal;


### PR DESCRIPTION
Adding the !impotant instruction in order to fix some compatibility issue.

The new editor_for_symphony created a bug where the icons would not get displayed.
