### PR TITLE
Compatibility with Symphony 2.5

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -14,7 +14,7 @@
 		</author>
 	</authors>
 	<releases>
-		<release version="1.0" date="2013-10-20" min="2.3.x">
+		<release version="1.0" date="2013-10-20" min="2.3.x" max="2.5">
 			<![CDATA[- Initial commit]]>
 		</release>
 	</releases>


### PR DESCRIPTION
Your extension is compatible with 2.4 and 2.5beta2 so I guess it's
safe to tag it as such.
